### PR TITLE
allow more condensed hex ip without separator

### DIFF
--- a/nipio/backend.py
+++ b/nipio/backend.py
@@ -204,6 +204,10 @@ class DynamicBackend:
         return os.path.join(os.path.dirname(os.path.realpath(__file__)), 'backend.conf')
 
     def _split_subdomain(self, subdomain):
+        match = re.search("(?:^|.*[.-])([0-9A-Fa-f]{8})$", subdomain)
+        if match:
+          s = match.group(1)
+          return [str(int(i, 16)) for i in [s[j:j+2] for j in (0,2,4,6)]]
         return re.split("[.-]", subdomain)
 
 

--- a/nipio_tests/backend_test.py
+++ b/nipio_tests/backend_test.py
@@ -99,6 +99,50 @@ class DynamicBackendTest(unittest.TestCase):
             ["DATA", "subdomain-127-0-0-1.lcl.io", "IN", "NS", "200", "22", "ns2.lcl.io"],
         )
 
+    def test_backend_responds_to_A_request_with_valid_ip_hexstring(self):
+        self._send_commands(["Q", "user-deadbeef.lcl.io", "IN", "A", "1", "127.0.0.1"])
+
+        self._run_backend()
+
+        self._assert_expected_responses(
+            ["DATA", "user-deadbeef.lcl.io", "IN", "A", "200", "22", "222.173.190.239"],
+            ["DATA", "user-deadbeef.lcl.io", "IN", "NS", "200", "22", "ns1.lcl.io"],
+            ["DATA", "user-deadbeef.lcl.io", "IN", "NS", "200", "22", "ns2.lcl.io"],
+        )
+
+    def test_backend_responds_to_long_hexstring_with_self(self):
+        self._send_commands(["Q", "deadbeefcafe.lcl.io", "IN", "A", "1", "127.0.0.1"])
+
+        self._run_backend()
+
+        self._assert_expected_responses(
+            ["DATA", "deadbeefcafe.lcl.io", "IN", "A", "200", "22", "127.0.0.33"],
+            ["DATA", "deadbeefcafe.lcl.io", "IN", "NS", "200", "22", "ns1.lcl.io"],
+            ["DATA", "deadbeefcafe.lcl.io", "IN", "NS", "200", "22", "ns2.lcl.io"],
+        )
+
+    def test_backend_responds_to_short_hexstring_with_self(self):
+        self._send_commands(["Q", "user-dec0ded.lcl.io", "IN", "A", "1", "127.0.0.1"])
+
+        self._run_backend()
+
+        self._assert_expected_responses(
+            ["DATA", "user-dec0ded.lcl.io", "IN", "A", "200", "22", "127.0.0.33"],
+            ["DATA", "user-dec0ded.lcl.io", "IN", "NS", "200", "22", "ns1.lcl.io"],
+            ["DATA", "user-dec0ded.lcl.io", "IN", "NS", "200", "22", "ns2.lcl.io"],
+        )
+
+    def test_backend_responds_to_invalid_hexstring_with_self(self):
+        self._send_commands(["Q", "deadcode.lcl.io", "IN", "A", "1", "127.0.0.1"])
+
+        self._run_backend()
+
+        self._assert_expected_responses(
+            ["DATA", "deadcode.lcl.io", "IN", "A", "200", "22", "127.0.0.33"],
+            ["DATA", "deadcode.lcl.io", "IN", "NS", "200", "22", "ns1.lcl.io"],
+            ["DATA", "deadcode.lcl.io", "IN", "NS", "200", "22", "ns2.lcl.io"],
+        )
+
     def test_backend_responds_to_invalid_ip_in_ANY_request_with_self_ip(self):
         self._send_commands(["Q", "subdomain.127.0.1.lcl.io", "IN", "ANY", "1", "127.0.0.1"])
 


### PR DESCRIPTION
For example
`dhcp-74cbff44.nip.io` vs
`user-116-203-255-68.nip.io`