### PR TITLE
add nip-io util for users to be able to "generate" addresses

### DIFF
--- a/nip-io
+++ b/nip-io
@@ -1,34 +1,37 @@
 #!/usr/bin/env python3
-# This script given ip address will give 
-# correct representation of URLs you could
-# use for nip.io resolver
-# bellow you can find example execution of this script
-#
-# shell> ./nip-io  10.22.33.44 mygreatapp
-#
-# IP 10.22.33.44
-# ==================
-# NIP_plain     http://mygreatapp-10.22.33.44.nip.io
-# NIP_plain_TLS https://mygreatapp-10.22.33.44.nip.io
-# NIP_DASH      http://mygreatapp-10-22-33-44.nip.io
-# NIP_DASH_TLS  https://mygreatapp-10-22-33-44.nip.io
-# ##### upper case hex
-# NIP_HEX       http://MYGREATAPP-0A16212C.nip.io
-# NIP_HEX_TLS   https://MYGREATAPP-0A16212C.nip.io
-# ##### lower case hex
-# NIP_HEX       http://mygreatapp-0a16212c.nip.io
-# NIP_TLS       https://mygreatapp-0a16212c.nip.io
-# #### upper case dash
-# NIP_DASH      http://MYGREATAPP-10-22-33-44.nip.io
-# NIP_DASH_TLS  https://MYGREATAPP-10-22-33-44.nip.io
-# #### lower case dash
-# NIP_DASH      http://mygreatapp-10-22-33-44.nip.io
-# NIP_DASH_TLS  https://mygreatapp-10-22-33-44.nip.io
-# #### NOT implemented at this time on nip.io
-# #### does not work, but will look to change that :)
-# NIP_B36       http://mygreatapp-c8slxm.nip.io
-# NIP_B36_TLS   https://mygreatapp-c8slxm.nip.io
+"""
+nip.io URL generation script
 
+This script given an IP address will give correct representation of URLs you could
+use for the nip.io resolver below you can find example execution of this script.
+
+Example:
+
+    $ ./nip-io 10.22.33.44 mygreatapp
+    
+    IP 10.22.33.44
+    ==================
+    NIP_plain     http://mygreatapp-10.22.33.44.nip.io
+    NIP_plain_TLS https://mygreatapp-10.22.33.44.nip.io
+    NIP_DASH      http://mygreatapp-10-22-33-44.nip.io
+    NIP_DASH_TLS  https://mygreatapp-10-22-33-44.nip.io
+    ##### upper case hex
+    NIP_HEX       http://MYGREATAPP-0A16212C.nip.io
+    NIP_HEX_TLS   https://MYGREATAPP-0A16212C.nip.io
+    ##### lower case hex
+    NIP_HEX       http://mygreatapp-0a16212c.nip.io
+    NIP_TLS       https://mygreatapp-0a16212c.nip.io
+    #### upper case dash
+    NIP_DASH      http://MYGREATAPP-10-22-33-44.nip.io
+    NIP_DASH_TLS  https://MYGREATAPP-10-22-33-44.nip.io
+    #### lower case dash
+    NIP_DASH      http://mygreatapp-10-22-33-44.nip.io
+    NIP_DASH_TLS  https://mygreatapp-10-22-33-44.nip.io
+    #### NOT implemented at this time on nip.io
+    #### does not work, but will look to change that :)
+    NIP_B36       http://mygreatapp-c8slxm.nip.io
+    NIP_B36_TLS   https://mygreatapp-c8slxm.nip.io
+"""
 
 import ipaddress
 import socket


### PR DESCRIPTION
example run of script with application name
```
steki@pc:~/GITHUB/nip.io> ./nip-io 192.168.100.114 aapp

IP 192.168.100.114
==================
NIP_plain     http://aapp-192.168.100.114.nip.io
NIP_plain_SSL https://aapp-192.168.100.114.nip.io
NIP_DASH      http://aapp-192-168-100-114.nip.io
NIP_DASH_SSL  https://aapp-192-168-100-114.nip.io
##### upper case hex
NIP_HEX       http://AAPP-C0A86472.nip.io
NIP_HEX_SSL   https://AAPP-C0A86472.nip.io
##### lower case hex
NIP_HEX       http://aapp-c0a86472.nip.io
NIP_SSL       https://aapp-c0a86472.nip.io
#### upper case dash
NIP_DASH      http://AAPP-192-168-100-114.nip.io
NIP_DASH_SSL  https://AAPP-192-168-100-114.nip.io
#### lower case dash
NIP_DASH      http://aapp-192-168-100-114.nip.io
NIP_DASH_SSL  https://aapp-192-168-100-114.nip.io

```
and now one without application name
```
steki@pc:~/GITHUB/nip.io> ./nip-io 192.168.100.114 

IP 192.168.100.114
==================
NIP_plain     http://192.168.100.114.nip.io
NIP_plain_SSL https://192.168.100.114.nip.io
NIP_DASH      http://192-168-100-114.nip.io
NIP_DASH_SSL  https://192-168-100-114.nip.io
##### upper case hex
NIP_HEX       http://C0A86472.nip.io
NIP_HEX_SSL   https://C0A86472.nip.io
##### lower case hex
NIP_HEX       http://c0a86472.nip.io
NIP_SSL       https://c0a86472.nip.io
#### upper case dash
NIP_DASH      http://192-168-100-114.nip.io
NIP_DASH_SSL  https://192-168-100-114.nip.io
#### lower case dash
NIP_DASH      http://192-168-100-114.nip.io
NIP_DASH_SSL  https://192-168-100-114.nip.io

steki@pc:~/GITHUB/nip.io> 
```