### PR TITLE
Add support for specifying CAA records

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ An IP address must be in one of the whitelisted ranges for a response to be retu
 
 `NIPIO_BLACKLIST`: A space-separated list of description=ip blacklisted pairs. Example: `some_description=10.0.0.1 other_description=10.0.0.2`.
 
+`NIPIO_CAA`: A space-separated list of description=value pairs for CAA `issue` records returned for whitelisted IPs. Example: `letsencrypt=letsencrypt.org`.
+
 This is useful if you're creating your own [Dockerfile](Dockerfile).
 
 ## Troubleshooting

--- a/nipio/backend.conf
+++ b/nipio/backend.conf
@@ -50,3 +50,11 @@ private_net_192_168 = 192.168.0.0/16
 # blacklisted ips (optional)
 [blacklist]
 some_description = 10.0.0.1
+
+
+# CAA `issue` records to include for whitelisted IPs.
+[caa]
+# To limit to Lets Encrypt only:
+# letsencrypt=letsencrypt.org
+# To block all CAs from issuing certificates:
+# deny_all=;

--- a/nipio_tests/backend_test.conf
+++ b/nipio_tests/backend_test.conf
@@ -47,3 +47,8 @@ private_net = 192.168.0.0/16
 # blacklist
 [blacklist]
 some_description = 10.0.0.100
+
+
+# CAA
+[caa]
+letsencrypt = letsencrypt.org;validationmethods=http-01


### PR DESCRIPTION
This allows specifying which CA authorities are allowed to issue certificates for subdomains or disallow issuing certificates entirely. This is disabled by default and is intended for situations where having valid TLS certificates is not necessary and it's not desirable to have a malicious IP (eg. phishing site) potentially appear more legitimate due to the valid certificate.

This commit includes a couple minor fixes:

- `_get_env_splitted()` now calls `split(..., 1)` instead of `split(..., 2)`, which actually produces up to 3 parts.
- The individual `_write("END")` calls in various qtype handlers were replaced by a single `write_end()` call at the end of `run()`'s loop.